### PR TITLE
Fix crontab to actually be every 30 mins

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
   schedule:
-    # At every minute past every hour on every day-of-week from Monday through Friday
-    - cron: '* */1 * * 1-5'
+    # Every 30 minutes, Monday through Friday
+    - cron: '*/30 * * * 1-5'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Previous value was meant to be hourly, but that was wrong. It was actually running every minute, but GitHub throttles it so it only ran every 10 mins or so. Every 30 mins is a more reasonable value.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>